### PR TITLE
Check for active_query in error_response

### DIFF
--- a/lib/Database/Async/Engine/PostgreSQL.pm
+++ b/lib/Database/Async/Engine/PostgreSQL.pm
@@ -572,10 +572,13 @@ sub protocol {
                 }),
                 error_response => $self->$curry::weak(sub {
                     my ($self, $msg) = @_;
-                    my $query = $self->active_query;
-                    $log->warnf('Query returned error %s for %s', $msg->error, $self->active_query);
-                    my $f = $query->completed;
-                    $f->fail($msg->error) unless $f->is_ready;
+                    if(my $query = $self->active_query) {
+                        $log->warnf('Query returned error %s for %s', $msg->error, $self->active_query);
+                        my $f = $query->completed;
+                        $f->fail($msg->error) unless $f->is_ready;
+                    } else {
+                        $log->errorf('Received error %s with no active query', $msg->error);
+                    }
                 }),
                 copy_in_response => $self->$curry::weak(sub {
                     my ($self, $msg) = @_;


### PR DESCRIPTION
Check if there's any active_query in response for errors.
In case the database connection was terminated this would fail.