### PR TITLE
patch/query-error-should-not-kill-connection

### DIFF
--- a/lib/Database/Async/Engine/PostgreSQL.pm
+++ b/lib/Database/Async/Engine/PostgreSQL.pm
@@ -768,6 +768,17 @@ sub protocol {
                     $log->tracef('Ready for query, state is %s', $msg->state);
                     $self->ready_for_query->set_string($msg->state);
                     $self->db->engine_ready($self) if $self->db;
+                    if ($self->{active_query}) {
+                        $log->tracef('There is a active query and we received ready_for_query.');
+                        if ($self->{active_query}->completed->is_ready) {
+                            # Fallback
+                            $log->tracef('The query is finalized, will remove it now.');
+                            delete $self->{active_query};
+                        }
+                        else {
+                            $log->tracef('Query is not finalized yet, the message might be send as part of initial connection setup flow. Not messing around with it');
+                        }
+                    }
                 }),
                 backend_key_data => $self->$curry::weak(sub {
                     my ($self, $msg) = @_;

--- a/lib/Database/Async/Engine/PostgreSQL.pm
+++ b/lib/Database/Async/Engine/PostgreSQL.pm
@@ -766,8 +766,6 @@ sub protocol {
                 ready_for_query => $self->$curry::weak(sub {
                     my ($self, $msg) = @_;
                     $log->tracef('Ready for query, state is %s', $msg->state);
-                    $self->ready_for_query->set_string($msg->state);
-                    $self->db->engine_ready($self) if $self->db;
                     if ($self->{active_query}) {
                         $log->tracef('There is a active query and we received ready_for_query.');
                         if ($self->{active_query}->completed->is_ready) {
@@ -779,6 +777,8 @@ sub protocol {
                             $log->tracef('Query is not finalized yet, the message might be send as part of initial connection setup flow. Not messing around with it');
                         }
                     }
+                    $self->ready_for_query->set_string($msg->state);
+                    $self->db->engine_ready($self) if $self->db;
                 }),
                 backend_key_data => $self->$curry::weak(sub {
                     my ($self, $msg) = @_;

--- a/t/error_handling.t
+++ b/t/error_handling.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+
+use feature qw(state);
+no indirect;
+
+use Test::More;
+use Test::Fatal;
+use Test::Deep;
+use Future::AsyncAwait;
+use IO::Async::Loop;
+use Database::Async;
+use Database::Async::Engine::PostgreSQL;
+use Log::Any::Adapter qw(TAP);
+use Log::Any qw($log);
+
+plan skip_all => 'set DATABASE_ASYNC_PG_TEST env var to test, but be prepared for it to *delete any and all data* in that database' unless exists $ENV{DATABASE_ASYNC_PG_TEST};
+
+my $loop = IO::Async::Loop->new;
+
+my $db;
+is(exception {
+    $loop->add(
+        $db = Database::Async->new(
+            type => 'postgresql',
+        )
+    );
+}, undef, 'can safely add to the loop');
+
+$log->infof('Sending a valid query');
+await $db->query('SELECT 1;')->single;
+$log->infof('Basic query works');
+my $exception = exception{$db->query('SELECT 1/0')->void->get};
+isa_ok ($exception, 'Protocol::Database::PostgreSQL::Error', 'Query failed as expected');
+$log->infof('Sending a new query through the same connection should works');
+await $db->query('SELECT 1;')->single;
+
+done_testing;
+


### PR DESCRIPTION
Make sure that handle is usable after SQL error being raised from PostgreSQL side, provided that the connection toward it are still valid.